### PR TITLE
Fixed a bug in the PrimaryCurveOKP method 

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -20,7 +20,6 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6Zh
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e h1:N7DeIrjYszNmSW409R3frPPwglRwMkXSBzwVbkOjLLA=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/jwk/ketspec_test.go
+++ b/jwk/ketspec_test.go
@@ -1,0 +1,63 @@
+package jwk
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const keys = `{
+  "keys": [
+    {
+      "kty": "OKP",
+      "d": "90nsVfpAV2VNrrGt75mGLWg-RL4sQLWk7EKslfOrloo",
+      "use": "enc",
+      "crv": "X25519",
+      "kid": "8a97d682-455a-4035-beae-f66f92854474",
+      "x": "zK8ckoiw9cYsvgrQ-GXMgAqHVOq-I_l8uwlryLHMh3A"
+    },
+    {
+      "kty": "EC",
+      "d": "1GIXPYYL9igpx97XRsB8FKfFD5fLrSKx7yLzGO5MvnA",
+      "crv": "P-256",
+      "x": "kk9qrjU7wfrO6d3rY7F41aUvVLKdYLgf0m6TE1rQLSk",
+"kid": "key1",
+      "y": "vA5j-Kzy2qTtlyPeJ1apoc_7viZV-wq1Fw_BDCVcahk"
+    },
+    {
+      "kty": "OKP",
+      "d": "Du6aSH_9vKXrSZOj-kf4CuOdkX5Rla0RbURzQR5z1Co",
+      "use": "sig",
+      "crv": "Ed25519",
+      "kid": "ba9091cf-8e19-4d9c-b5fe-8fb94d33f7d1",
+      "x": "u4lAEsFy5rRrjJLVFfgerZZC0nsT1KDZV9FQ-_59ES0"
+    }
+  ]
+}
+`
+
+var _ = Describe("Key spec set", func() {
+	keySpecSet := new(KeySpecSet)
+	BeforeEach(func() {
+		err := json.Unmarshal([]byte(keys), keySpecSet)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	It("should return the primary Ed25519 key", func() {
+		keySpec, keyPair := keySpecSet.PrimaryCurveOKP("Ed25519")
+		Expect(keySpec.KeyID).To(Equal("ba9091cf-8e19-4d9c-b5fe-8fb94d33f7d1"))
+		Expect(keyPair.Curve()).To(Equal("Ed25519"))
+	})
+
+	It("should return the primary key OKP key type", func() {
+		keySpec := keySpecSet.PrimaryKey("OKP")
+		Expect(keySpec.KeyID).To(Equal("8a97d682-455a-4035-beae-f66f92854474"))
+	})
+
+	It("should return the primary ECDSA private key", func() {
+		keySpec, privateKey := keySpecSet.PrimaryECDSAPrivate()
+		Expect(keySpec.KeyID).To(Equal("key1"))
+		Expect(privateKey.Curve.Params().Name).To(Equal("P-256"))
+	})
+})

--- a/jwk/marshal_rsa_test.go
+++ b/jwk/marshal_rsa_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/jwk/util_primary.go
+++ b/jwk/util_primary.go
@@ -2,6 +2,7 @@ package jwk
 
 import (
 	"crypto/ecdsa"
+
 	"github.com/rakutentech/jwk-go/okp"
 )
 
@@ -31,7 +32,9 @@ func (ks KeySpecSet) PrimaryKey(keyType string) *KeySpec {
 func (ks KeySpecSet) PrimaryCurveOKP(curve string) (*KeySpec, okp.CurveOctetKeyPair) {
 	for _, k := range ks.Keys {
 		curveOKP := k.CoerceOkpCurve(curve)
-		return &k, curveOKP
+		if curveOKP != nil {
+			return &k, curveOKP
+		}
 	}
 	return nil, nil
 }


### PR DESCRIPTION
If you have a key set like this:
```
"keys": [
    {
      "kty": "OKP",
      "d": "90nsVfpAV2VNrrGt75mGLWg-RL4sQLWk7EKslfOrloo",
      "use": "enc",
      "crv": "X25519",
      "kid": "8a97d682-455a-4035-beae-f66f92854474",
      "x": "zK8ckoiw9cYsvgrQ-GXMgAqHVOq-I_l8uwlryLHMh3A"
    },
    {
      "kty": "OKP",
      "d": "Du6aSH_9vKXrSZOj-kf4CuOdkX5Rla0RbURzQR5z1Co",
      "use": "sig",
      "crv": "Ed25519",
      "kid": "ba9091cf-8e19-4d9c-b5fe-8fb94d33f7d1",
      "x": "u4lAEsFy5rRrjJLVFfgerZZC0nsT1KDZV9FQ-_59ES0"
    }
]
```

I think calling `PrimaryCurveOKP("Ed25519") ` should return the key with ID `ba9091cf-8e19-4d9c-b5fe-8fb94d33f7d1`.
But it is returning nil values.

