### PR TITLE
Fix jwk/KeySpec.IsValid()

### DIFF
--- a/jwk/keyspec.go
+++ b/jwk/keyspec.go
@@ -119,7 +119,7 @@ func (k *KeySpec) PublicOnly() (*KeySpec, error) {
 
 // IsValid returns true if the key is valid, i.e. it is not expired yet or has no expiry set
 func (k *KeySpec) IsValid() bool {
-	return k.ExpiresAt.IsZero() || k.ExpiresAt.Before(time.Now())
+	return k.ExpiresAt.IsZero() || k.ExpiresAt.After(time.Now())
 }
 
 // Clone creates a copy of a KeySpec


### PR DESCRIPTION
`IsValid()` did not in fact check if the JWK is expired, but the opposite.\
If `ExpiresAt` is in the future, it returned `false` where it should have returned `true`.\
Tests were added to ensure this. 